### PR TITLE
fix javadoc warnings

### DIFF
--- a/helloRPC/src/org/epics/exampleJava/helloRPC/HelloClient.java
+++ b/helloRPC/src/org/epics/exampleJava/helloRPC/HelloClient.java
@@ -50,7 +50,7 @@ public class HelloClient
 	 * 
 	 * @param args - the name of person to greet
 	 */
-	public static void main(String[] args) throws Throwable
+	public static void main(String[] args) 
 	{
 		// Start the pvAccess client side.
 		org.epics.pvaccess.ClientFactory.start();

--- a/helloRPC/src/org/epics/exampleJava/helloRPC/HelloService.java
+++ b/helloRPC/src/org/epics/exampleJava/helloRPC/HelloService.java
@@ -77,17 +77,18 @@ public class HelloService
 	/**
 	 * Main is the entry point of the HelloService server side executable. 
 	 * @param args None
-	 * @throws PVAException
 	 */
-	public static void main(String[] args) throws PVAException
+	public static void main(String[] args) 
 	{
 		RPCServer server = new RPCServer();
-
 		// register our service as "helloService"
 		server.registerService("helloService", new HelloServiceImpl());
-
 		server.printInfo();
-		server.run(0);
+		try {
+			server.run(0);
+		} catch (PVAException e) {
+			System.err.println(e.getMessage());
+			System.exit(1);
+		}
 	}
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -127,11 +127,8 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <overview>documentation/pvExampleTestJava.html</overview>
-                </configuration>
             </plugin>
-
+ 
             <plugin> 
                 <artifactId>maven-deploy-plugin</artifactId> 
                 <version>2.8.2</version> 


### PR DESCRIPTION
Fix the javadoc warnings.

mvn package still produces one warning:
[WARNING] Ignoring project type pom - supportedProjectTypes = [jar, bundle]

I tried to remove it but have not been successful.
