### PR TITLE
clients and servers only use required providers; use eclipse to make src indentation uniform

### DIFF
--- a/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/ArrayPerformance.java
+++ b/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/ArrayPerformance.java
@@ -22,12 +22,12 @@ public class ArrayPerformance extends PVRecord implements RunnableReady {
 
     private int size;
     private long delayMilli;
-    
+
 
     public static ArrayPerformance  create(String recordName,int size,double delay)
     {
         PVStructure pvs = StandardPVFieldFactory.getStandardPVField().scalarArray(
-            ScalarType.pvLong,"value,timeStamp.alarm");
+                ScalarType.pvLong,"value,timeStamp.alarm");
         return  new ArrayPerformance(recordName,pvs,size,delay);
     }
 
@@ -40,7 +40,7 @@ public class ArrayPerformance extends PVRecord implements RunnableReady {
 
     public void startThread()
     {
-        
+
         threadCreate.create("arrayPerformance",ThreadPriority.getJavaPriority(ThreadPriority.middle), this);
     }
 

--- a/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/ArrayPerformanceMain.java
+++ b/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/ArrayPerformanceMain.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 import org.epics.pvaClient.PvaClient;
-import org.epics.pvaccess.PVAConstants;
 import org.epics.pvaccess.PVAException;
 import org.epics.pvaccess.client.ChannelProvider;
 import org.epics.pvaccess.server.impl.remote.ServerContextImpl;
@@ -44,37 +43,37 @@ public class ArrayPerformanceMain {
         System.out.print(providerName + " ");
         System.out.println(nMonitor);
         try {
-        	PVDatabase master = PVDatabaseFactory.getMaster();
-        	ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
-        	ServerContextImpl context = ServerContextImpl.startPVAServer(PVAConstants.PVA_ALL_PROVIDERS,0,true,null);
-        	PvaClient pva= PvaClient.get();
-        	ArrayPerformance arrayPerformance = ArrayPerformance.create(recordName,size,delay);
-        	master.addRecord(arrayPerformance);
-        	arrayPerformance.startThread();
-        	LongArrayMonitor[] longArrayMonitor = new LongArrayMonitor[nMonitor];
-        	for(int i=0; i<nMonitor; ++i) longArrayMonitor[i]= new LongArrayMonitor(providerName,recordName);
-        	while(true) {
-        		System.out.print("waiting for exit: ");
-        		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-        		String value = null;
-        		try {
-        			value = br.readLine();
-        		} catch (IOException ioe) {
-        			System.out.println("IO error trying to read input!");
-        		}
-        		if(value.equals("exit")) break;
-        	}
-        	for(int i=0; i<nMonitor; ++i) {
+            PVDatabase master = PVDatabaseFactory.getMaster();
+            ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
+            ServerContextImpl context = ServerContextImpl.startPVAServer("local",0,true,null);
+            PvaClient pva= PvaClient.get(providerName);
+            ArrayPerformance arrayPerformance = ArrayPerformance.create(recordName,size,delay);
+            master.addRecord(arrayPerformance);
+            arrayPerformance.startThread();
+            LongArrayMonitor[] longArrayMonitor = new LongArrayMonitor[nMonitor];
+            for(int i=0; i<nMonitor; ++i) longArrayMonitor[i]= new LongArrayMonitor(providerName,recordName);
+            while(true) {
+                System.out.print("waiting for exit: ");
+                BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                String value = null;
+                try {
+                    value = br.readLine();
+                } catch (IOException ioe) {
+                    System.out.println("IO error trying to read input!");
+                }
+                if(value.equals("exit")) break;
+            }
+            for(int i=0; i<nMonitor; ++i) {
                 longArrayMonitor[i].stop();
             }
             arrayPerformance.stop();
-        	context.destroy();
-        	master.destroy();
-        	channelProvider.destroy();
-        	pva.destroy();
+            context.destroy();
+            master.destroy();
+            channelProvider.destroy();
+            pva.destroy();
         } catch (PVAException e) {
-        	System.out.println("exception " + e.getMessage());
-        	System.exit(1);
+            System.out.println("exception " + e.getMessage());
+            System.exit(1);
         }
         System.out.println("arrayPerformance exiting");
     }

--- a/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayGet.java
+++ b/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayGet.java
@@ -19,7 +19,7 @@ import org.epics.pvdata.pv.PVStructure;
 
 public class LongArrayGet implements RunnableReady {
 
-    
+
     private static ThreadCreate threadCreate = ThreadCreateFactory.getThreadCreate();
     private String providerName;
     private String channelName;
@@ -28,14 +28,14 @@ public class LongArrayGet implements RunnableReady {
     private double delayTime;
     private AtomicBoolean runStop = new AtomicBoolean(false);
     private AtomicBoolean runReturn = new AtomicBoolean(false);
-   
+
 
     public LongArrayGet(
-         String providerName,
-         String channelName,
-         int iterBetweenCreateChannel,
-         int iterBetweenCreateChannelGet,
-         double delayTime)
+            String providerName,
+            String channelName,
+            int iterBetweenCreateChannel,
+            int iterBetweenCreateChannelGet,
+            double delayTime)
     {
         this.providerName = providerName;
         this.channelName = channelName;
@@ -45,7 +45,7 @@ public class LongArrayGet implements RunnableReady {
         threadCreate.create(
                 "longArrayGet",ThreadPriority.getJavaPriority(ThreadPriority.middle), this);
     }
-    
+
     public void stop()
     {
         if(!runStop.compareAndSet(false, true)) return;
@@ -61,7 +61,7 @@ public class LongArrayGet implements RunnableReady {
 
     public void run(ThreadReady threadReady)
     {
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get(providerName);
         PvaClientChannel pvaChannel = pva.channel(channelName,providerName,5.0);
         PvaClientGet pvaGet = pvaChannel.createGet("value,alarm,timeStamp");
         TimeStamp timeStamp = TimeStampFactory.create();
@@ -128,9 +128,9 @@ public class LongArrayGet implements RunnableReady {
                 if(numChannelGet>=iterBetweenCreateChannelGet) createGet = true;
             }
             if(createGet) {
-                 numChannelGet = 0;
-                 pvaGet.destroy();
-                 pvaGet = pvaChannel.createGet("value,alarm,timeStamp");
+                numChannelGet = 0;
+                pvaGet.destroy();
+                pvaGet = pvaChannel.createGet("value,alarm,timeStamp");
             }
             ++numChannelCreate;
             if(iterBetweenCreateChannel!=0) {

--- a/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayGetMain.java
+++ b/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayGetMain.java
@@ -26,7 +26,7 @@ public class LongArrayGetMain {
         if(argc>3) delayTime = Double.parseDouble(args[3]);
         try {
             LongArrayGet longArrayGet = new LongArrayGet(
-                "pva",channelName,iterBetweenCreateChannel,iterBetweenCreateChannelGet,delayTime);
+                    "pva",channelName,iterBetweenCreateChannel,iterBetweenCreateChannelGet,delayTime);
             while(true) {
                 Console cnsl = null;
                 try{

--- a/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayMonitor.java
+++ b/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayMonitor.java
@@ -18,7 +18,7 @@ import org.epics.pvdata.pv.PVStructure;
 
 public class LongArrayMonitor implements RunnableReady {
 
-    
+
     private static ThreadCreate threadCreate = ThreadCreateFactory.getThreadCreate();
     private AtomicBoolean runStop = new AtomicBoolean(false);
     private AtomicBoolean runReturn = new AtomicBoolean(false);
@@ -31,7 +31,7 @@ public class LongArrayMonitor implements RunnableReady {
         this.channelName = channelName;
         threadCreate.create("longArrayMonitor",ThreadPriority.getJavaPriority(ThreadPriority.middle), this);
     }
-     
+
     public void stop()
     {
         if(!runStop.compareAndSet(false, true)) return;
@@ -44,10 +44,10 @@ public class LongArrayMonitor implements RunnableReady {
             }
         }
     }
-    
+
     public void run(ThreadReady threadReady)
     {
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get(providerName);
         PvaClientMonitor monitor = pva.channel(channelName,providerName,5.0).monitor("value,timeStamp,alarm");
         TimeStamp timeStamp = TimeStampFactory.create();
         TimeStamp timeStampLast = TimeStampFactory.create();

--- a/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayPut.java
+++ b/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayPut.java
@@ -18,7 +18,7 @@ import org.epics.pvdata.pv.PVStructure;
 
 public class LongArrayPut implements RunnableReady {
 
-    
+
     private static ThreadCreate threadCreate = ThreadCreateFactory.getThreadCreate();
     private String providerName;
     private String channelName;
@@ -28,12 +28,12 @@ public class LongArrayPut implements RunnableReady {
     private double delayTime;
     private AtomicBoolean runStop = new AtomicBoolean(false);
     private AtomicBoolean runReturn = new AtomicBoolean(false);
-    
+
 
     public LongArrayPut(
             String providerName, String channelName,
-         int arraySize,
-         int iterBetweenCreateChannel,int iterBetweenCreateChannelPut,double delayTime)
+            int arraySize,
+            int iterBetweenCreateChannel,int iterBetweenCreateChannelPut,double delayTime)
     {
         this.providerName = providerName;
         this.channelName = channelName;
@@ -42,7 +42,7 @@ public class LongArrayPut implements RunnableReady {
         this.iterBetweenCreateChannelPut = iterBetweenCreateChannelPut;
         this.delayTime = delayTime;
         threadCreate.create(
-            "longArrayPut",ThreadPriority.getJavaPriority(ThreadPriority.middle), this);
+                "longArrayPut",ThreadPriority.getJavaPriority(ThreadPriority.middle), this);
     }
 
     public void stop()
@@ -60,7 +60,7 @@ public class LongArrayPut implements RunnableReady {
 
     public void run(ThreadReady threadReady)
     {
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get(providerName);
         PvaClientChannel pvaChannel = pva.channel(channelName,providerName,5.0);
         PvaClientPut pvaPut = pvaChannel.createPut("value");
         TimeStamp timeStamp = TimeStampFactory.create();
@@ -125,9 +125,9 @@ public class LongArrayPut implements RunnableReady {
                 if(numChannelPut>=iterBetweenCreateChannelPut) createPut = true;
             }
             if(createPut) {
-                 pvaPut.destroy();
-                 pvaPut = pvaChannel.createPut("value,timeStamp,alarm");
-                 numChannelPut = 0;
+                pvaPut.destroy();
+                pvaPut = pvaChannel.createPut("value,timeStamp,alarm");
+                numChannelPut = 0;
             }
             ++numChannelCreate;
             if(iterBetweenCreateChannel!=0) {

--- a/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayPutMain.java
+++ b/arrayPerformance/src/org/epics/exampleJava/arrayPerformance/LongArrayPutMain.java
@@ -14,7 +14,7 @@ public class LongArrayPutMain {
         double delayTime = 1.0;
         if(argc==1 && args[0].endsWith("-help")) {
             System.out.println("channelName arraySize iterBetweenCreateChannel "
-                 + "iterBetweenCreateChannelPut delayTime");
+                    + "iterBetweenCreateChannelPut delayTime");
             System.out.println("default");
             System.out.print(channelName);
             System.out.print(" " + arraySize);
@@ -30,12 +30,12 @@ public class LongArrayPutMain {
         if(argc>4) delayTime = Double.parseDouble(args[4]);
         try {
             LongArrayPut longArrayPut = new LongArrayPut(
-                "pva",
-                channelName,
-                arraySize,
-                iterBetweenCreateChannel,
-                iterBetweenCreateChannelPut,
-                delayTime);
+                    "pva",
+                    channelName,
+                    arraySize,
+                    iterBetweenCreateChannel,
+                    iterBetweenCreateChannelPut,
+                    delayTime);
             while(true) {
                 Console cnsl = null;
                 try{

--- a/database/src/org/epics/exampleJava/exampleDatabase/ExampleDatabase.java
+++ b/database/src/org/epics/exampleJava/exampleDatabase/ExampleDatabase.java
@@ -19,7 +19,6 @@ import org.epics.nt.NTScalar;
 import org.epics.nt.NTScalarArray;
 import org.epics.nt.NTScalarArrayBuilder;
 import org.epics.nt.NTScalarBuilder;
-import org.epics.pvaccess.PVAConstants;
 import org.epics.pvaccess.PVAException;
 import org.epics.pvaccess.client.ChannelProvider;
 import org.epics.pvaccess.server.impl.remote.ServerContextImpl;
@@ -44,110 +43,110 @@ import org.epics.pvdatabase.pva.ChannelProviderLocalFactory;
  *
  */
 public class ExampleDatabase {
- 
+
     private static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
     private static final StandardField standardField = StandardFieldFactory.getStandardField();
     private static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
 
-static void createStructureArrayRecord(
-    PVDatabase master,
-    String recordName)
-{
-    Structure top = fieldCreate.createFieldBuilder().
-         addNestedStructureArray("value").
-             add("name",ScalarType.pvString).
-             add("value",ScalarType.pvString).
-             endNested().
-         createStructure();
-    PVStructure pvStructure = pvDataCreate.createPVStructure(top);
-    PVRecord pvRecord = new PVRecord(recordName,pvStructure);
-    boolean result = master.addRecord(pvRecord); 
-    if(!result) throw new RuntimeException(recordName + " not added");
-}
+    static void createStructureArrayRecord(
+            PVDatabase master,
+            String recordName)
+    {
+        Structure top = fieldCreate.createFieldBuilder().
+                addNestedStructureArray("value").
+                add("name",ScalarType.pvString).
+                add("value",ScalarType.pvString).
+                endNested().
+                createStructure();
+        PVStructure pvStructure = pvDataCreate.createPVStructure(top);
+        PVRecord pvRecord = new PVRecord(recordName,pvStructure);
+        boolean result = master.addRecord(pvRecord); 
+        if(!result) throw new RuntimeException(recordName + " not added");
+    }
 
-static void createRestrictedUnionRecord(
-    PVDatabase master,
-    String recordName)
-{
-    Structure top = fieldCreate.createFieldBuilder().
-         addNestedUnion("value").
-             add("string",ScalarType.pvString).
-             addArray("stringArray",ScalarType.pvString).
-             endNested().
-         createStructure();
-    PVStructure pvStructure = pvDataCreate.createPVStructure(top);
-    PVRecord pvRecord = new PVRecord(recordName,pvStructure);
-    boolean result = master.addRecord(pvRecord);
-    if(!result) throw new RuntimeException(recordName + " not added");
-}
+    static void createRestrictedUnionRecord(
+            PVDatabase master,
+            String recordName)
+    {
+        Structure top = fieldCreate.createFieldBuilder().
+                addNestedUnion("value").
+                add("string",ScalarType.pvString).
+                addArray("stringArray",ScalarType.pvString).
+                endNested().
+                createStructure();
+        PVStructure pvStructure = pvDataCreate.createPVStructure(top);
+        PVRecord pvRecord = new PVRecord(recordName,pvStructure);
+        boolean result = master.addRecord(pvRecord);
+        if(!result) throw new RuntimeException(recordName + " not added");
+    }
 
-static void createVariantUnionRecord(
-    PVDatabase master,
-    String recordName)
-{
-    Structure top = fieldCreate.createFieldBuilder().
-         add("value",fieldCreate.createVariantUnion()).
-         createStructure();
-    PVStructure pvStructure = pvDataCreate.createPVStructure(top);
-    PVRecord pvRecord = new PVRecord(recordName,pvStructure);
-    boolean result = master.addRecord(pvRecord);
-    if(!result) throw new RuntimeException(recordName + " not added");
-}
+    static void createVariantUnionRecord(
+            PVDatabase master,
+            String recordName)
+    {
+        Structure top = fieldCreate.createFieldBuilder().
+                add("value",fieldCreate.createVariantUnion()).
+                createStructure();
+        PVStructure pvStructure = pvDataCreate.createPVStructure(top);
+        PVRecord pvRecord = new PVRecord(recordName,pvStructure);
+        boolean result = master.addRecord(pvRecord);
+        if(!result) throw new RuntimeException(recordName + " not added");
+    }
 
-static void createRegularUnionArrayRecord(
-    PVDatabase master,
-    String recordName)
-{
-    Structure top = fieldCreate.createFieldBuilder().
-         addNestedUnionArray("value").
-             add("string",ScalarType.pvString).
-             addArray("stringArray",ScalarType.pvString).
-             endNested().
-         createStructure();
-    PVStructure pvStructure = pvDataCreate.createPVStructure(top);
-    PVRecord pvRecord = new PVRecord(recordName,pvStructure);
-    boolean result = master.addRecord(pvRecord);
-    if(!result) throw new RuntimeException(recordName + " not added");
-}
+    static void createRegularUnionArrayRecord(
+            PVDatabase master,
+            String recordName)
+    {
+        Structure top = fieldCreate.createFieldBuilder().
+                addNestedUnionArray("value").
+                add("string",ScalarType.pvString).
+                addArray("stringArray",ScalarType.pvString).
+                endNested().
+                createStructure();
+        PVStructure pvStructure = pvDataCreate.createPVStructure(top);
+        PVRecord pvRecord = new PVRecord(recordName,pvStructure);
+        boolean result = master.addRecord(pvRecord);
+        if(!result) throw new RuntimeException(recordName + " not added");
+    }
 
-static void createVariantUnionArrayRecord(
-    PVDatabase master,
-    String recordName)
-{
-    Structure top = fieldCreate.createFieldBuilder().
-         addArray("value",fieldCreate.createVariantUnion()).
-         createStructure();
-    PVStructure pvStructure = pvDataCreate.createPVStructure(top);
-    PVRecord pvRecord = new PVRecord(recordName,pvStructure);
-    boolean result = master.addRecord(pvRecord);
-    if(!result) throw new RuntimeException(recordName + " not added");
-}
+    static void createVariantUnionArrayRecord(
+            PVDatabase master,
+            String recordName)
+    {
+        Structure top = fieldCreate.createFieldBuilder().
+                addArray("value",fieldCreate.createVariantUnion()).
+                createStructure();
+        PVStructure pvStructure = pvDataCreate.createPVStructure(top);
+        PVRecord pvRecord = new PVRecord(recordName,pvStructure);
+        boolean result = master.addRecord(pvRecord);
+        if(!result) throw new RuntimeException(recordName + " not added");
+    }
 
-static void createDumbPowerSupplyRecord(
-    PVDatabase master,
-    String recordName)
-{
-     Structure top = fieldCreate.createFieldBuilder().
-         add("alarm",standardField.alarm()) .
-            add("timeStamp",standardField.timeStamp()) .
-            addNestedStructure("power") .
-               add("value",ScalarType.pvDouble) .
-               add("alarm",standardField.alarm()) .
-               endNested().
-            addNestedStructure("voltage") .
-               add("value",ScalarType.pvDouble) .
-               add("alarm",standardField.alarm()) .
-               endNested().
-            addNestedStructure("current") .
-               add("value",ScalarType.pvDouble) .
-               add("alarm",standardField.alarm()) .
-               endNested().
-            createStructure();
-    PVStructure pvStructure = pvDataCreate.createPVStructure(top);
-    PVRecord pvRecord = new PVRecord(recordName,pvStructure);
-    boolean result = master.addRecord(pvRecord);
-    if(!result) throw new RuntimeException(recordName + " not added");
-}
+    static void createDumbPowerSupplyRecord(
+            PVDatabase master,
+            String recordName)
+    {
+        Structure top = fieldCreate.createFieldBuilder().
+                add("alarm",standardField.alarm()) .
+                add("timeStamp",standardField.timeStamp()) .
+                addNestedStructure("power") .
+                add("value",ScalarType.pvDouble) .
+                add("alarm",standardField.alarm()) .
+                endNested().
+                addNestedStructure("voltage") .
+                add("value",ScalarType.pvDouble) .
+                add("alarm",standardField.alarm()) .
+                endNested().
+                addNestedStructure("current") .
+                add("value",ScalarType.pvDouble) .
+                add("alarm",standardField.alarm()) .
+                endNested().
+                createStructure();
+        PVStructure pvStructure = pvDataCreate.createPVStructure(top);
+        PVRecord pvRecord = new PVRecord(recordName,pvStructure);
+        boolean result = master.addRecord(pvRecord);
+        if(!result) throw new RuntimeException(recordName + " not added");
+    }
 
     private static void createRecords(
             PVDatabase master,
@@ -157,9 +156,9 @@ static void createDumbPowerSupplyRecord(
         String recordName = recordNamePrefix;
         NTScalarBuilder ntScalarBuilder = NTScalar.createBuilder();
         PVStructure pvStructure = ntScalarBuilder.
-            value(scalarType).
-            addAlarm().addTimeStamp().
-            createPVStructure();
+                value(scalarType).
+                addAlarm().addTimeStamp().
+                createPVStructure();
         PVRecord pvRecord = new PVRecord(recordName,pvStructure);
         master.addRecord(pvRecord);
         recordName += "Array";
@@ -174,74 +173,74 @@ static void createDumbPowerSupplyRecord(
 
     public static void main(String[] args)
     {
-    	try {
-    		PVDatabase master = PVDatabaseFactory.getMaster();
-    		ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
+        try {
+            PVDatabase master = PVDatabaseFactory.getMaster();
+            ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
 
-    		createRecords(master,ScalarType.pvBoolean,"PVRboolean");
-    		createRecords(master,ScalarType.pvByte,"PVRbyte");
-    		createRecords(master,ScalarType.pvShort,"PVRshort");
-    		createRecords(master,ScalarType.pvInt,"PVRint");
-    		createRecords(master,ScalarType.pvLong,"PVRlong");
-    		createRecords(master,ScalarType.pvUByte,"PVRubyte");
-    		createRecords(master,ScalarType.pvUShort,"PVRushort");
-    		createRecords(master,ScalarType.pvUInt,"PVRuint");
-    		createRecords(master,ScalarType.pvULong,"PVRulong");
-    		createRecords(master,ScalarType.pvFloat,"PVRfloat");
-    		createRecords(master,ScalarType.pvDouble,"PVRdouble");
-    		createRecords(master,ScalarType.pvString,"PVRstring");
+            createRecords(master,ScalarType.pvBoolean,"PVRboolean");
+            createRecords(master,ScalarType.pvByte,"PVRbyte");
+            createRecords(master,ScalarType.pvShort,"PVRshort");
+            createRecords(master,ScalarType.pvInt,"PVRint");
+            createRecords(master,ScalarType.pvLong,"PVRlong");
+            createRecords(master,ScalarType.pvUByte,"PVRubyte");
+            createRecords(master,ScalarType.pvUShort,"PVRushort");
+            createRecords(master,ScalarType.pvUInt,"PVRuint");
+            createRecords(master,ScalarType.pvULong,"PVRulong");
+            createRecords(master,ScalarType.pvFloat,"PVRfloat");
+            createRecords(master,ScalarType.pvDouble,"PVRdouble");
+            createRecords(master,ScalarType.pvString,"PVRstring");
 
-    		createRecords(master,ScalarType.pvDouble,"PVRdouble01");
-    		createRecords(master,ScalarType.pvDouble,"PVRdouble02");
-    		createRecords(master,ScalarType.pvDouble,"PVRdouble03");
-    		createRecords(master,ScalarType.pvDouble,"PVRdouble04");
-    		createRecords(master,ScalarType.pvDouble,"PVRdouble05");
+            createRecords(master,ScalarType.pvDouble,"PVRdouble01");
+            createRecords(master,ScalarType.pvDouble,"PVRdouble02");
+            createRecords(master,ScalarType.pvDouble,"PVRdouble03");
+            createRecords(master,ScalarType.pvDouble,"PVRdouble04");
+            createRecords(master,ScalarType.pvDouble,"PVRdouble05");
 
-    		NTEnumBuilder ntEnumBuilder = NTEnum.createBuilder();
-    		PVStructure pvStructure = ntEnumBuilder.
-    				addAlarm().addTimeStamp().
-    				createPVStructure();
-    		String[] choices = new String[2];
-    		choices[0] = "zero";
-    		choices[1] = "one";
-    		PVStringArray pvChoices = pvStructure.getSubField(PVStringArray.class,"value.choices");
-    		pvChoices.put(0, 2, choices, 0);
-    		PVRecord pvRecord = new PVRecord("PVRenum",pvStructure);
-    		master.addRecord(pvRecord);
+            NTEnumBuilder ntEnumBuilder = NTEnum.createBuilder();
+            PVStructure pvStructure = ntEnumBuilder.
+                    addAlarm().addTimeStamp().
+                    createPVStructure();
+            String[] choices = new String[2];
+            choices[0] = "zero";
+            choices[1] = "one";
+            PVStringArray pvChoices = pvStructure.getSubField(PVStringArray.class,"value.choices");
+            pvChoices.put(0, 2, choices, 0);
+            PVRecord pvRecord = new PVRecord("PVRenum",pvStructure);
+            master.addRecord(pvRecord);
 
-    		createStructureArrayRecord(master,"PVRstructureArray");
-    		createRestrictedUnionRecord(master,"PVRrestrictedUnion");
-    		createVariantUnionRecord(master,"PVRvariantUnion");
-    		createRegularUnionArrayRecord(master,"PVRrestrictedUnionArray");
-    		createVariantUnionArrayRecord(master,"PVRvariantUnionArray");
-    		createDumbPowerSupplyRecord(master,"PVRdumbPowerSupply");
+            createStructureArrayRecord(master,"PVRstructureArray");
+            createRestrictedUnionRecord(master,"PVRrestrictedUnion");
+            createVariantUnionRecord(master,"PVRvariantUnion");
+            createRegularUnionArrayRecord(master,"PVRrestrictedUnionArray");
+            createVariantUnionArrayRecord(master,"PVRvariantUnionArray");
+            createDumbPowerSupplyRecord(master,"PVRdumbPowerSupply");
 
-    		String recordName = "PVRhelloPutGet";
-    		pvRecord = ExampleHelloRecord.create(recordName);
-    		master.addRecord(pvRecord);
+            String recordName = "PVRhelloPutGet";
+            pvRecord = ExampleHelloRecord.create(recordName);
+            master.addRecord(pvRecord);
 
-    		recordName = "helloRPC";
-    		pvRecord = ExampleHelloRPC.create(recordName);
-    		master.addRecord(pvRecord);
-    		ServerContextImpl context = ServerContextImpl.startPVAServer(PVAConstants.PVA_ALL_PROVIDERS,0,true,null); 
-    		while(true) {
-    			System.out.print("waiting for exit: ");
-    			BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-    			String value = null;
-    			try {
-    				value = br.readLine();
-    			} catch (IOException ioe) {
-    				System.out.println("IO error trying to read input!");
-    			}
-    			if(value.equals("exit")) break;
-    		}
-    		context.destroy();
-    		master.destroy();
-    		channelProvider.destroy();
-    	} catch (PVAException e) {
-    		System.err.println(e.getMessage());
-    		System.exit(1);
-    	}
-    	System.out.println("ExampleDatabase exiting");
+            recordName = "helloRPC";
+            pvRecord = ExampleHelloRPC.create(recordName);
+            master.addRecord(pvRecord);
+            ServerContextImpl context = ServerContextImpl.startPVAServer(channelProvider.getProviderName(),0,true,null); 
+            while(true) {
+                System.out.print("waiting for exit: ");
+                BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                String value = null;
+                try {
+                    value = br.readLine();
+                } catch (IOException ioe) {
+                    System.out.println("IO error trying to read input!");
+                }
+                if(value.equals("exit")) break;
+            }
+            context.destroy();
+            master.destroy();
+            channelProvider.destroy();
+        } catch (PVAException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+        System.out.println("ExampleDatabase exiting");
     }
 }

--- a/database/src/org/epics/exampleJava/exampleDatabase/ExampleHelloRPC.java
+++ b/database/src/org/epics/exampleJava/exampleDatabase/ExampleHelloRPC.java
@@ -24,75 +24,75 @@ import org.epics.pvaccess.server.rpc.*;
 import org.epics.pvdatabase.*;
 
 public class ExampleHelloRPC extends PVRecord {
-	private static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
-	private static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
+    private static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
+    private static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
 
 
-	private final static Structure resultStructure = fieldCreate.createFieldBuilder().
-			add("value",ScalarType.pvString).createStructure();
+    private final static Structure resultStructure = fieldCreate.createFieldBuilder().
+            add("value",ScalarType.pvString).createStructure();
 
-	private final static PVStructure pvResult = pvDataCreate
-			.createPVStructure(resultStructure);
+    private final static PVStructure pvResult = pvDataCreate
+            .createPVStructure(resultStructure);
 
-	private boolean     underControl = false;
+    private boolean     underControl = false;
 
-	synchronized boolean takeControl() {
-		if (!underControl) {
-			underControl = true;
-			return true;
-		}
-		return false;
-	}
+    synchronized boolean takeControl() {
+        if (!underControl) {
+            underControl = true;
+            return true;
+        }
+        return false;
+    }
 
-	synchronized void releaseControl() {
-		underControl = false;
-	}
+    synchronized void releaseControl() {
+        underControl = false;
+    }
 
-	static class RPCServiceImpl implements RPCService {
+    static class RPCServiceImpl implements RPCService {
 
-		private ExampleHelloRPC pvRecord;
+        private ExampleHelloRPC pvRecord;
 
-		RPCServiceImpl(ExampleHelloRPC record) {
-			pvRecord = record;
-		}
+        RPCServiceImpl(ExampleHelloRPC record) {
+            pvRecord = record;
+        }
 
-		public PVStructure request(PVStructure args) throws RPCRequestException
-		{
-			boolean haveControl = pvRecord.takeControl();
-			if (!haveControl)
-				throw new RPCRequestException(StatusType.ERROR,
-						"Device busy");
-			PVString pvFrom = args.getSubField(PVString.class,"value");
-			if (pvFrom == null)
-				throw new RPCRequestException(StatusType.ERROR,
-						"PVString field with name 'value' expected.");
+        public PVStructure request(PVStructure args) throws RPCRequestException
+        {
+            boolean haveControl = pvRecord.takeControl();
+            if (!haveControl)
+                throw new RPCRequestException(StatusType.ERROR,
+                        "Device busy");
+            PVString pvFrom = args.getSubField(PVString.class,"value");
+            if (pvFrom == null)
+                throw new RPCRequestException(StatusType.ERROR,
+                        "PVString field with name 'value' expected.");
 
-			PVString pvTo = pvResult.getSubField(PVString.class,"value");
-			pvTo.put("Hello " + pvFrom.get());
-			pvRecord.releaseControl();
-			return pvResult;
+            PVString pvTo = pvResult.getSubField(PVString.class,"value");
+            pvTo.put("Hello " + pvFrom.get());
+            pvRecord.releaseControl();
+            return pvResult;
 
-		}
-	}
+        }
+    }
 
-	public static ExampleHelloRPC create(String recordName)
-	{
+    public static ExampleHelloRPC create(String recordName)
+    {
 
-		ExampleHelloRPC pvRecord = new ExampleHelloRPC(recordName,pvResult);
-		PVDatabase master = PVDatabaseFactory.getMaster();
-		master.addRecord(pvRecord);
-		return pvRecord;
-	}
+        ExampleHelloRPC pvRecord = new ExampleHelloRPC(recordName,pvResult);
+        PVDatabase master = PVDatabaseFactory.getMaster();
+        master.addRecord(pvRecord);
+        return pvRecord;
+    }
 
-	public ExampleHelloRPC(String recordName, PVStructure pvStructure) {
-		super(recordName, pvStructure);
-		process();
-	}
+    public ExampleHelloRPC(String recordName, PVStructure pvStructure) {
+        super(recordName, pvStructure);
+        process();
+    }
 
 
-	public Service getService(PVStructure pvRequest)
-	{
-		return new RPCServiceImpl(this);
-	}
+    public Service getService(PVStructure pvRequest)
+    {
+        return new RPCServiceImpl(this);
+    }
 
 }

--- a/database/src/org/epics/exampleJava/exampleDatabase/ExampleHelloRecord.java
+++ b/database/src/org/epics/exampleJava/exampleDatabase/ExampleHelloRecord.java
@@ -28,7 +28,7 @@ public class ExampleHelloRecord extends PVRecord {
     private static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
     private static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
     private static final StandardField standardField = StandardFieldFactory.getStandardField();
-    
+
     private PVString arg;
     private PVString result;
 
@@ -36,18 +36,18 @@ public class ExampleHelloRecord extends PVRecord {
     {
         FieldBuilder fb = fieldCreate.createFieldBuilder();
         Structure structure = 
-            fb.addNestedStructure("argument").
+                fb.addNestedStructure("argument").
                 add("value",ScalarType.pvString).
                 endNested().
-            addNestedStructure("result").
+                addNestedStructure("result").
                 add("value",ScalarType.pvString).
                 endNested().
-            add("timeStamp",standardField.timeStamp()).
-            createStructure();
-       PVRecord pvRecord = new ExampleHelloRecord(recordName,pvDataCreate.createPVStructure(structure));
-       PVDatabase master = PVDatabaseFactory.getMaster();
-       master.addRecord(pvRecord);
-       return pvRecord;
+                add("timeStamp",standardField.timeStamp()).
+                createStructure();
+        PVRecord pvRecord = new ExampleHelloRecord(recordName,pvDataCreate.createPVStructure(structure));
+        PVDatabase master = PVDatabaseFactory.getMaster();
+        master.addRecord(pvRecord);
+        return pvRecord;
     }
     public ExampleHelloRecord(String recordName,PVStructure pvStructure) {
         super(recordName,pvStructure);
@@ -55,9 +55,9 @@ public class ExampleHelloRecord extends PVRecord {
         if(arg==null) throw new IllegalArgumentException("arg not found");
         result = pvStructure.getSubField(PVString.class, "result.value");
         if(result==null) throw new IllegalArgumentException("result not found");
-        
+
     }
-    
+
     public void process()
     {
         int level = getTraceLevel();

--- a/exampleClient/src/org/epics/exampleClient/ExamplePvaClientGet.java
+++ b/exampleClient/src/org/epics/exampleClient/ExamplePvaClientGet.java
@@ -90,7 +90,7 @@ public class ExamplePvaClientGet
     public static void main( String[] args )
     {
         System.out.println("_____examplePvaClientGet starting_______");
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get("pva ca");
         try {
             exampleDouble(pva,"PVRdouble","pva");
             exampleDoubleArray(pva,"PVRdoubleArray","pva");

--- a/exampleClient/src/org/epics/exampleClient/ExamplePvaClientMonitor.java
+++ b/exampleClient/src/org/epics/exampleClient/ExamplePvaClientMonitor.java
@@ -46,7 +46,7 @@ public class ExamplePvaClientMonitor
     public static void main( String[] args )
     {
         System.out.println("_____examplePvaClientMonitor starting_______");
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get("pva ca");
         try {
             exampleMonitor(pva,"PVRdouble","pva");
             PvaClientChannel pvaChannel = pva.createChannel("DBRdouble00","ca");

--- a/exampleClient/src/org/epics/exampleClient/ExamplePvaClientMultiDouble.java
+++ b/exampleClient/src/org/epics/exampleClient/ExamplePvaClientMultiDouble.java
@@ -78,7 +78,7 @@ public class ExamplePvaClientMultiDouble
     public static void main( String[] args )
     {
         System.out.println("_____examplePvaClientMultiDouble starting_______");
-        PvaClient pva = PvaClient.get();
+        PvaClient pva = PvaClient.get("pva ca");
         try {
             int num = 5;
             String[] names = new String[num];

--- a/exampleClient/src/org/epics/exampleClient/ExamplePvaClientNTMulti.java
+++ b/exampleClient/src/org/epics/exampleClient/ExamplePvaClientNTMulti.java
@@ -153,7 +153,7 @@ public class ExamplePvaClientNTMulti
     public static void main( String[] args )
     {
         System.out.println( "_____examplePvaClientNTMulti starting_______");  
-        PvaClient pva = PvaClient.get();
+        PvaClient pva = PvaClient.get("pva ca");
         try {
             int num = 4;
             String[] channelNames = new String[num];

--- a/exampleClient/src/org/epics/exampleClient/ExamplePvaClientProcess.java
+++ b/exampleClient/src/org/epics/exampleClient/ExamplePvaClientProcess.java
@@ -31,7 +31,7 @@ public class ExamplePvaClientProcess
 
     public static void main( String[] args )
     {
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get("pva");
         try {
             exampleProcess(pva);
         }

--- a/exampleClient/src/org/epics/exampleClient/ExamplePvaClientPut.java
+++ b/exampleClient/src/org/epics/exampleClient/ExamplePvaClientPut.java
@@ -89,7 +89,7 @@ public class ExamplePvaClientPut
     public static void main( String[] args )
     {
         System.out.println("_____examplePvaClientPut starting_______");
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get("pva ca");
         try {
             exampleDouble(pva,"PVRdouble","pva");
             exampleDoubleArray(pva,"PVRdoubleArray","pva");

--- a/exampleClient/src/org/epics/exampleClient/HelloWorldPutGet.java
+++ b/exampleClient/src/org/epics/exampleClient/HelloWorldPutGet.java
@@ -45,7 +45,7 @@ public class HelloWorldPutGet
 
     public static void main( String[] args )
     {
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get("pva");
         try {
             exampleSimple(pva);
         }

--- a/exampleLink/src/org/epics/exampleJava/exampleLink/DoubleArrayMain.java
+++ b/exampleLink/src/org/epics/exampleJava/exampleLink/DoubleArrayMain.java
@@ -23,7 +23,6 @@ import org.epics.pvdatabase.PVDatabase;
 import org.epics.pvdatabase.PVDatabaseFactory;
 import org.epics.pvdatabase.PVRecord;
 import org.epics.pvdatabase.pva.ChannelProviderLocalFactory;
-import org.epics.pvaClient.*;
 
 
 /**
@@ -32,47 +31,47 @@ import org.epics.pvaClient.*;
  */
 public class DoubleArrayMain {
 
-	public static void main(String[] args)
-	{
-		int argc = args.length;
-		String doubleArrayRecordName = "doubleArray";
-		if(argc==1 && args[0].endsWith("-help")) {
-			System.out.println("doubleArrayRecordName");
-			System.out.println("default");
-			System.out.println(doubleArrayRecordName);
-			System.exit(0);
-		}
-		if(argc>0) doubleArrayRecordName = args[0];
-		try {
-			PVDatabase master = PVDatabaseFactory.getMaster();
-			ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
-			NTScalarArrayBuilder builder = NTScalarArray.createBuilder();
-			PVStructure pvStructure = builder.
-					value(ScalarType.pvDouble).
-					addAlarm().
-					addTimeStamp().
-					createPVStructure();
-			master.addRecord(new PVRecord(doubleArrayRecordName,pvStructure));
+    public static void main(String[] args)
+    {
+        int argc = args.length;
+        String doubleArrayRecordName = "doubleArray";
+        if(argc==1 && args[0].endsWith("-help")) {
+            System.out.println("doubleArrayRecordName");
+            System.out.println("default");
+            System.out.println(doubleArrayRecordName);
+            System.exit(0);
+        }
+        if(argc>0) doubleArrayRecordName = args[0];
+        try {
+            PVDatabase master = PVDatabaseFactory.getMaster();
+            ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
+            NTScalarArrayBuilder builder = NTScalarArray.createBuilder();
+            PVStructure pvStructure = builder.
+                    value(ScalarType.pvDouble).
+                    addAlarm().
+                    addTimeStamp().
+                    createPVStructure();
+            master.addRecord(new PVRecord(doubleArrayRecordName,pvStructure));
 
-			ServerContextImpl context = ServerContextImpl.startPVAServer(PVAConstants.PVA_ALL_PROVIDERS,0,true,null);
-			while(true) {
-				System.out.print("waiting for exit: ");
-				BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-				String value = null;
-				try {
-					value = br.readLine();
-				} catch (IOException ioe) {
-					System.out.println("IO error trying to read input!");
-				}
-				if(value.equals("exit")) break;
-			}
-			context.destroy();
-			master.destroy();
-			channelProvider.destroy();
-			System.out.println("ExampleLink exiting");
-		} catch (PVAException e) {
-			System.err.println(e.getMessage());
-			System.exit(1);
-		}
-	}
+            ServerContextImpl context = ServerContextImpl.startPVAServer(PVAConstants.PVA_ALL_PROVIDERS,0,true,null);
+            while(true) {
+                System.out.print("waiting for exit: ");
+                BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                String value = null;
+                try {
+                    value = br.readLine();
+                } catch (IOException ioe) {
+                    System.out.println("IO error trying to read input!");
+                }
+                if(value.equals("exit")) break;
+            }
+            context.destroy();
+            master.destroy();
+            channelProvider.destroy();
+            System.out.println("ExampleLink exiting");
+        } catch (PVAException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+    }
 }

--- a/exampleLink/src/org/epics/exampleJava/exampleLink/ExampleLinkClient.java
+++ b/exampleLink/src/org/epics/exampleJava/exampleLink/ExampleLinkClient.java
@@ -21,16 +21,16 @@ public class ExampleLinkClient
     public static void main( String[] args )
     {
         int argc = args.length;
-		String provider = "pva";
-		if(argc==1 && args[0].endsWith("-help")) {
-			System.out.println("provider");
-			System.out.println("default");
-			System.out.println(provider);
-			System.exit(0);
-		}
-		System.out.println("_____exampleLinkClient starting_______");
-	    if(argc>0) provider = args[0];
-        PvaClient pva= PvaClient.get();
+        String provider = "pva";
+        if(argc==1 && args[0].endsWith("-help")) {
+            System.out.println("provider");
+            System.out.println("default");
+            System.out.println(provider);
+            System.exit(0);
+        }
+        System.out.println("_____exampleLinkClient starting_______");
+        if(argc>0) provider = args[0];
+        PvaClient pva= PvaClient.get(provider);
         try {
             PvaClientPut put = pva.channel("doubleArray",provider,5.0).put();
             PvaClientPutData putData = put.getData();

--- a/exampleLink/src/org/epics/exampleJava/exampleLink/ExampleLinkMain.java
+++ b/exampleLink/src/org/epics/exampleJava/exampleLink/ExampleLinkMain.java
@@ -13,7 +13,7 @@ import java.io.InputStreamReader;
 
 import org.epics.nt.NTScalarArray;
 import org.epics.nt.NTScalarArrayBuilder;
-import org.epics.pvaccess.PVAConstants;
+import org.epics.pvaClient.PvaClient;
 import org.epics.pvaccess.PVAException;
 import org.epics.pvaccess.client.ChannelProvider;
 import org.epics.pvaccess.server.impl.remote.ServerContextImpl;
@@ -23,7 +23,6 @@ import org.epics.pvdatabase.PVDatabase;
 import org.epics.pvdatabase.PVDatabaseFactory;
 import org.epics.pvdatabase.PVRecord;
 import org.epics.pvdatabase.pva.ChannelProviderLocalFactory;
-import org.epics.pvaClient.*;
 
 
 /**
@@ -32,62 +31,61 @@ import org.epics.pvaClient.*;
  */
 public class ExampleLinkMain {
 
-	public static void main(String[] args)
-	{
-		int argc = args.length;
-		String provider = "pva";
-		String exampleLinkRecordName = "exampleLink";
-		String linkedRecordName = "doubleArray";
-		boolean generateLinkedRecord = true;
-		if(argc==1 && args[0].endsWith("-help")) {
-			System.out.println("provider exampleLinkRecordName linkedRecordName generateLinkedRecord");
-			System.out.println("default");
-			System.out.println(provider + " " + exampleLinkRecordName + " " + linkedRecordName + " " + generateLinkedRecord);
-			System.exit(0);
-		}
-		if(argc>0) provider = args[0];
-		if(argc>1) exampleLinkRecordName = args[1];
-		if(argc>2) linkedRecordName = args[2];
-		if(argc>3) {
-			String val = args[3];
-			if(val.equals("false")) generateLinkedRecord = false;
-		}
-		try {
-			PVDatabase master = PVDatabaseFactory.getMaster();
-			ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
-			if(generateLinkedRecord) {
-				NTScalarArrayBuilder builder = NTScalarArray.createBuilder();
-				PVStructure pvStructure = builder.
-						value(ScalarType.pvDouble).
-						addAlarm().
-						addTimeStamp().
-						createPVStructure();
-				master.addRecord(new PVRecord(linkedRecordName,pvStructure));
-			}
-			ServerContextImpl context = ServerContextImpl.startPVAServer(PVAConstants.PVA_ALL_PROVIDERS,0,true,null);
-            PvaClient pva= PvaClient.get();
-			PVRecord pvRecord = ExampleLinkRecord.create(pva,exampleLinkRecordName,provider,linkedRecordName);
-			master.addRecord(pvRecord);
-//			ServerContextImpl context = ServerContextImpl.startPVAServer(PVAConstants.PVA_ALL_PROVIDERS,0,true,null);
-			while(true) {
-				System.out.print("waiting for exit: ");
-				BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-				String value = null;
-				try {
-					value = br.readLine();
-				} catch (IOException ioe) {
-					System.out.println("IO error trying to read input!");
-				}
-				if(value.equals("exit")) break;
-			}
-			context.destroy();
-			master.destroy();
-			channelProvider.destroy();
-			pva.destroy();
-			System.out.println("ExampleLink exiting");
-		} catch (PVAException e) {
-			System.err.println(e.getMessage());
-			System.exit(1);
-		}
-	}
+    public static void main(String[] args)
+    {
+        int argc = args.length;
+        String provider = "pva";
+        String exampleLinkRecordName = "exampleLink";
+        String linkedRecordName = "doubleArray";
+        boolean generateLinkedRecord = true;
+        if(argc==1 && args[0].endsWith("-help")) {
+            System.out.println("provider exampleLinkRecordName linkedRecordName generateLinkedRecord");
+            System.out.println("default");
+            System.out.println(provider + " " + exampleLinkRecordName + " " + linkedRecordName + " " + generateLinkedRecord);
+            System.exit(0);
+        }
+        if(argc>0) provider = args[0];
+        if(argc>1) exampleLinkRecordName = args[1];
+        if(argc>2) linkedRecordName = args[2];
+        if(argc>3) {
+            String val = args[3];
+            if(val.equals("false")) generateLinkedRecord = false;
+        }
+        try {
+            PVDatabase master = PVDatabaseFactory.getMaster();
+            ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
+            if(generateLinkedRecord) {
+                NTScalarArrayBuilder builder = NTScalarArray.createBuilder();
+                PVStructure pvStructure = builder.
+                        value(ScalarType.pvDouble).
+                        addAlarm().
+                        addTimeStamp().
+                        createPVStructure();
+                master.addRecord(new PVRecord(linkedRecordName,pvStructure));
+            }
+            ServerContextImpl context = ServerContextImpl.startPVAServer("local",0,true,System.out);
+            PvaClient pva= PvaClient.get(provider);
+            PVRecord pvRecord = ExampleLinkRecord.create(pva,exampleLinkRecordName,provider,linkedRecordName);
+            master.addRecord(pvRecord);
+            while(true) {
+                System.out.print("waiting for exit: ");
+                BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                String value = null;
+                try {
+                    value = br.readLine();
+                } catch (IOException ioe) {
+                    System.out.println("IO error trying to read input!");
+                }
+                if(value.equals("exit")) break;
+            }
+            context.destroy();
+            master.destroy();
+            channelProvider.destroy();
+            pva.destroy();
+            System.out.println("ExampleLink exiting");
+        } catch (PVAException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+    }
 }

--- a/exampleLink/src/org/epics/exampleJava/exampleLink/ExampleLinkRecord.java
+++ b/exampleLink/src/org/epics/exampleJava/exampleLink/ExampleLinkRecord.java
@@ -20,11 +20,11 @@ import org.epics.pvdata.pv.StandardPVField;
 import org.epics.pvdatabase.PVRecord;
 
 public class ExampleLinkRecord extends PVRecord
-    implements  PvaClientMonitorRequester
+implements  PvaClientMonitorRequester
 {
-	private static final StandardPVField standardPVField = StandardPVFieldFactory.getStandardPVField();
+    private static final StandardPVField standardPVField = StandardPVFieldFactory.getStandardPVField();
     private static Convert convert = ConvertFactory.getConvert();
-    
+
     private PVDoubleArray pvValue = null;
 
     public static PVRecord create(PvaClient pva,String recordName,String provider,String channelName)
@@ -38,7 +38,7 @@ public class ExampleLinkRecord extends PVRecord
     {
         super(recordName,pvStructure);
     }
-    
+
     private boolean init(PvaClient pva,String channelName,String provider)
     {
         PVStructure pvStructure = getPVRecordStructure().getPVStructure();
@@ -50,14 +50,14 @@ public class ExampleLinkRecord extends PVRecord
         pvaClientChannel.monitor("value",this);
         return true;
     }
-    
+
     @Override
-	public void event(PvaClientMonitor monitor) {
-    	while(monitor.poll()) {
+    public void event(PvaClientMonitor monitor) {
+        while(monitor.poll()) {
             PVStructure pvStructure = monitor.getData().getPVStructure();
             PVDoubleArray pvDoubleArray = pvStructure.getSubField(PVDoubleArray.class,"value");
             if(pvDoubleArray==null) throw new RuntimeException("value is not a double array");
-          
+
             lock();
             try {
                 beginGroupPut();
@@ -69,8 +69,8 @@ public class ExampleLinkRecord extends PVRecord
             }
             monitor.releaseEvent();
         } 
-	}
-    
+    }
+
     public void process()
     {
         super.process();

--- a/helloPutGet/src/org/epics/exampleJava/helloPutGet/HelloPutGetClient.java
+++ b/helloPutGet/src/org/epics/exampleJava/helloPutGet/HelloPutGetClient.java
@@ -22,9 +22,9 @@ public class HelloPutGetClient
 {
     public static void main( String[] args )
     {
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get("pva");
         try {
-        	PvaClientChannel channel = pva.channel("helloPutGet");
+            PvaClientChannel channel = pva.channel("helloPutGet");
             PvaClientPutGet putGet = channel.createPutGet();
             putGet.connect();
             PvaClientPutData putData = putGet.getPutData();

--- a/helloPutGet/src/org/epics/exampleJava/helloPutGet/HelloPutGetMain.java
+++ b/helloPutGet/src/org/epics/exampleJava/helloPutGet/HelloPutGetMain.java
@@ -11,7 +11,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import org.epics.pvaccess.PVAConstants;
 import org.epics.pvaccess.PVAException;
 import org.epics.pvaccess.client.ChannelProvider;
 import org.epics.pvaccess.server.impl.remote.ServerContextImpl;
@@ -27,33 +26,33 @@ import org.epics.pvdatabase.pva.ChannelProviderLocalFactory;
  */
 public class HelloPutGetMain {
 
-	public static void main(String[] args)
-	{
-		try {
-			PVDatabase master = PVDatabaseFactory.getMaster();
-			ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
-			String recordName = "helloPutGet";
-			PVRecord pvRecord = HelloPutGetRecord.create(recordName);
-			master.addRecord(pvRecord);
-			ServerContextImpl context = ServerContextImpl.startPVAServer(PVAConstants.PVA_ALL_PROVIDERS,0,true,null);
-			while(true) {
-				System.out.print("waiting for exit: ");
-				BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-				String value = null;
-				try {
-					value = br.readLine();
-				} catch (IOException ioe) {
-					System.out.println("IO error trying to read input!");
-				}
-				if(value.equals("exit")) break;
-			}
-			context.destroy();
-			master.destroy();
-			channelProvider.destroy();
-		} catch (PVAException e) {
-			System.err.println(e.getMessage());
-			System.exit(1);
-		}
-		System.out.println("ExampleLink exiting");
-	}
+    public static void main(String[] args)
+    {
+        try {
+            PVDatabase master = PVDatabaseFactory.getMaster();
+            ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
+            String recordName = "helloPutGet";
+            PVRecord pvRecord = HelloPutGetRecord.create(recordName);
+            master.addRecord(pvRecord);
+            ServerContextImpl context = ServerContextImpl.startPVAServer(channelProvider.getProviderName(),0,true,null);
+            while(true) {
+                System.out.print("waiting for exit: ");
+                BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                String value = null;
+                try {
+                    value = br.readLine();
+                } catch (IOException ioe) {
+                    System.out.println("IO error trying to read input!");
+                }
+                if(value.equals("exit")) break;
+            }
+            context.destroy();
+            master.destroy();
+            channelProvider.destroy();
+        } catch (PVAException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+        System.out.println("ExampleLink exiting");
+    }
 }

--- a/helloPutGet/src/org/epics/exampleJava/helloPutGet/HelloPutGetRecord.java
+++ b/helloPutGet/src/org/epics/exampleJava/helloPutGet/HelloPutGetRecord.java
@@ -20,50 +20,50 @@ import org.epics.pvdatabase.PVRecord;
 
 public class HelloPutGetRecord extends PVRecord
 {
-	private PVString pvArgumentValue = null;
-	private PVString pvResultValue = null;
-    
-   
+    private PVString pvArgumentValue = null;
+    private PVString pvResultValue = null;
+
+
 
     public static HelloPutGetRecord create(String recordName)
     {
-    	 StandardField standardField = StandardFieldFactory.getStandardField();
-    	    FieldCreate fieldCreate = FieldFactory.getFieldCreate();
-    	    PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
-    	    Structure topStructure = fieldCreate.createFieldBuilder().
-    	        addNestedStructure("argument").
-    	            add("value",ScalarType.pvString).
-    	            endNested().
-    	        addNestedStructure("result") .
-    	            add("value",ScalarType.pvString) .
-    	            add("timeStamp",standardField.timeStamp()) .
-    	            endNested().
-    	        createStructure();
-    	    PVStructure pvStructure = pvDataCreate.createPVStructure(topStructure);
+        StandardField standardField = StandardFieldFactory.getStandardField();
+        FieldCreate fieldCreate = FieldFactory.getFieldCreate();
+        PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
+        Structure topStructure = fieldCreate.createFieldBuilder().
+                addNestedStructure("argument").
+                add("value",ScalarType.pvString).
+                endNested().
+                addNestedStructure("result") .
+                add("value",ScalarType.pvString) .
+                add("timeStamp",standardField.timeStamp()) .
+                endNested().
+                createStructure();
+        PVStructure pvStructure = pvDataCreate.createPVStructure(topStructure);
 
-    	    HelloPutGetRecord pvRecord =
-    	        new HelloPutGetRecord(recordName,pvStructure);
-    	    if(!pvRecord.init()) return null;
-    	    return pvRecord;
+        HelloPutGetRecord pvRecord =
+                new HelloPutGetRecord(recordName,pvStructure);
+        if(!pvRecord.init()) return null;
+        return pvRecord;
     }
     public HelloPutGetRecord(String recordName,PVStructure pvStructure)
     {
         super(recordName,pvStructure);
     }
-    
+
     private boolean init()
     {
-    	PVStructure pvStructure = getPVRecordStructure().getPVStructure();
+        PVStructure pvStructure = getPVRecordStructure().getPVStructure();
         pvArgumentValue = pvStructure.getSubField(PVString.class,"argument.value");
         if(pvArgumentValue==null) return false;
         pvResultValue = pvStructure.getSubField(PVString.class,"result.value");
         if(pvResultValue==null) return false;
         return true;
     }
-    
+
     public void process()
     {
-    	pvResultValue.put("Hello " + pvArgumentValue.get());
+        pvResultValue.put("Hello " + pvArgumentValue.get());
         super.process();
     }
 }

--- a/helloRPC/src/org/epics/exampleJava/helloRPC/HelloClient.java
+++ b/helloRPC/src/org/epics/exampleJava/helloRPC/HelloClient.java
@@ -30,82 +30,82 @@ import org.epics.pvdata.pv.Structure;
  */
 public class HelloClient
 {
-	// Create the "data interface" required to send data to the hello service. That is,
-	// define the client side API of the hello service.
-	private final static FieldCreate fieldCreate = FieldFactory.getFieldCreate();
-	private final static Structure requestStructure =
-		fieldCreate.createStructure(
-				new String[] { "personsname" },
-				new Field[] { fieldCreate.createScalar(ScalarType.pvString) });
+    // Create the "data interface" required to send data to the hello service. That is,
+    // define the client side API of the hello service.
+    private final static FieldCreate fieldCreate = FieldFactory.getFieldCreate();
+    private final static Structure requestStructure =
+            fieldCreate.createStructure(
+                    new String[] { "personsname" },
+                    new Field[] { fieldCreate.createScalar(ScalarType.pvString) });
 
-	// Set a pvAccess connection timeout, after which the client gives up trying 
-	// to connect to server.
-	private final static double REQUEST_TIMEOUT = 3.0;
-	
-	/**
-	 * The main establishes the connection to the helloServer, constructs the
-	 * mechanism to pass parameters to the server, calls the server in the EV4
-	 * 2-step way, gets the response from the helloServer, unpacks it, and
-	 * prints the greeting.
-	 * 
-	 * @param args - the name of person to greet
-	 */
-	public static void main(String[] args) 
-	{
-		// Start the pvAccess client side.
-		org.epics.pvaccess.ClientFactory.start();
-		
-		try
-		{
-			// Create an RPC client to the "helloService" service
-			// (the connection has already started in background).
-			RPCClientImpl client = new RPCClientImpl("helloService");
-	
-			// Create the data instance used to send data to the server. That is,
-			// instantiate an instance of the "introspection interface" for the data interface of
-			// the hello server. The data interface was defined statically above.
-			PVStructure pvArguments =
-				PVDataFactory.getPVDataCreate().createPVStructure(requestStructure);
-			
-			// Get the value of the first input argument to this executable and use it 
-			// to set the data to be sent to the server through the introspection interface. 
-			String name = args.length > 0 ? args[0] : "anonymous";
-			pvArguments.getStringField("personsname").put(name);
-				
-			try
-			{
-				// Create an RPC request and block until response is received. There is
-				// no need to explicitly wait for connection; this method takes care of it.
-				// In case of an error, an exception is throw.
-				PVStructure pvResult = client.request(pvArguments, REQUEST_TIMEOUT);
-				
-				// Extract the result using the introspection interface of the returned 
-				// datum, and print it. This particular service never returns a null result.
-				String res = pvResult.getStringField("greeting").get();
-				System.out.println(res);
-			}
-			catch (RPCRequestException ex)
-			{
-				// The client connected to the server, but the server request method issued its 
-				// standard summary exception indicating it couldn't complete the requested task.
-				System.err.println("Acquisition of greeting was not successful, " +
-						"service responded with an error: " + ex.getMessage());
-			}
-			catch (IllegalStateException ex)
-			{
-				// The client failed to connect to the server. The server isn't running or
-				// some other network related error occurred.
-				System.err.println("Acquisition of greeting was not successful, " +
-						"failed to connect: "+ ex.getMessage());
-			}
-			
-			// Disconnect from the service client.
-			client.destroy();
-		}
-		finally
-		{
-			// Stop pvAccess client, so that this application exits cleanly.
-			org.epics.pvaccess.ClientFactory.stop();
-		}
-	}
+    // Set a pvAccess connection timeout, after which the client gives up trying 
+    // to connect to server.
+    private final static double REQUEST_TIMEOUT = 3.0;
+
+    /**
+     * The main establishes the connection to the helloServer, constructs the
+     * mechanism to pass parameters to the server, calls the server in the EV4
+     * 2-step way, gets the response from the helloServer, unpacks it, and
+     * prints the greeting.
+     * 
+     * @param args - the name of person to greet
+     */
+    public static void main(String[] args) 
+    {
+        // Start the pvAccess client side.
+        org.epics.pvaccess.ClientFactory.start();
+
+        try
+        {
+            // Create an RPC client to the "helloService" service
+            // (the connection has already started in background).
+            RPCClientImpl client = new RPCClientImpl("helloService");
+
+            // Create the data instance used to send data to the server. That is,
+            // instantiate an instance of the "introspection interface" for the data interface of
+            // the hello server. The data interface was defined statically above.
+            PVStructure pvArguments =
+                    PVDataFactory.getPVDataCreate().createPVStructure(requestStructure);
+
+            // Get the value of the first input argument to this executable and use it 
+            // to set the data to be sent to the server through the introspection interface. 
+            String name = args.length > 0 ? args[0] : "anonymous";
+            pvArguments.getStringField("personsname").put(name);
+
+            try
+            {
+                // Create an RPC request and block until response is received. There is
+                // no need to explicitly wait for connection; this method takes care of it.
+                // In case of an error, an exception is throw.
+                PVStructure pvResult = client.request(pvArguments, REQUEST_TIMEOUT);
+
+                // Extract the result using the introspection interface of the returned 
+                // datum, and print it. This particular service never returns a null result.
+                String res = pvResult.getStringField("greeting").get();
+                System.out.println(res);
+            }
+            catch (RPCRequestException ex)
+            {
+                // The client connected to the server, but the server request method issued its 
+                // standard summary exception indicating it couldn't complete the requested task.
+                System.err.println("Acquisition of greeting was not successful, " +
+                        "service responded with an error: " + ex.getMessage());
+            }
+            catch (IllegalStateException ex)
+            {
+                // The client failed to connect to the server. The server isn't running or
+                // some other network related error occurred.
+                System.err.println("Acquisition of greeting was not successful, " +
+                        "failed to connect: "+ ex.getMessage());
+            }
+
+            // Disconnect from the service client.
+            client.destroy();
+        }
+        finally
+        {
+            // Stop pvAccess client, so that this application exits cleanly.
+            org.epics.pvaccess.ClientFactory.stop();
+        }
+    }
 }

--- a/helloRPC/src/org/epics/exampleJava/helloRPC/HelloService.java
+++ b/helloRPC/src/org/epics/exampleJava/helloRPC/HelloService.java
@@ -31,64 +31,64 @@ import org.epics.pvdata.pv.Structure;
 public class HelloService
 {
 
-	// All EPICS V4 services return PVData objects (by definition). Create the
-	// factory object that will allow you to create the returned PVData object
-	// later.
-	//
-	private static final PVDataCreate pvDataCreate = 
-		PVDataFactory.getPVDataCreate();
-	private static final FieldCreate fieldCreate = 
-		FieldFactory.getFieldCreate();
+    // All EPICS V4 services return PVData objects (by definition). Create the
+    // factory object that will allow you to create the returned PVData object
+    // later.
+    //
+    private static final PVDataCreate pvDataCreate = 
+            PVDataFactory.getPVDataCreate();
+    private static final FieldCreate fieldCreate = 
+            FieldFactory.getFieldCreate();
 
-	// This service result structure type definition.
-	private final static Structure resultStructure = fieldCreate
-			.createStructure(
-					new String[] { "greeting" },
-					new Field[] { fieldCreate.createScalar(ScalarType.pvString) });
+    // This service result structure type definition.
+    private final static Structure resultStructure = fieldCreate
+            .createStructure(
+                    new String[] { "greeting" },
+                    new Field[] { fieldCreate.createScalar(ScalarType.pvString) });
 
-	/**
-	 * Implementation of RPC service.
-	 */
-	static class HelloServiceImpl implements RPCService
-	{
-		public PVStructure request(PVStructure args) throws RPCRequestException
-		{
-			// Extract the arguments. Just one in this case.
-			// Report an error by throwing a RPCRequestException.
-			PVString inputPersonNameField = args.getStringField("personsname");
-			if (inputPersonNameField == null)
-				throw new RPCRequestException(StatusType.ERROR,
-						"PVString field with name 'personsname' expected.");
+    /**
+     * Implementation of RPC service.
+     */
+    static class HelloServiceImpl implements RPCService
+    {
+        public PVStructure request(PVStructure args) throws RPCRequestException
+        {
+            // Extract the arguments. Just one in this case.
+            // Report an error by throwing a RPCRequestException.
+            PVString inputPersonNameField = args.getStringField("personsname");
+            if (inputPersonNameField == null)
+                throw new RPCRequestException(StatusType.ERROR,
+                        "PVString field with name 'personsname' expected.");
 
-			// Create the result structure of the data interface.
-			PVStructure result = pvDataCreate
-					.createPVStructure(resultStructure);
+            // Create the result structure of the data interface.
+            PVStructure result = pvDataCreate
+                    .createPVStructure(resultStructure);
 
-			// Extract from the constructed data interface the value of
-			// "greeting" field. The value we'll return, is "Hello" concatenated
-			// to the value of the input parameter called "personsname".
-			PVString greetingvalueField = result.getStringField("greeting");
-			greetingvalueField.put("Hello " + inputPersonNameField.get());
+            // Extract from the constructed data interface the value of
+            // "greeting" field. The value we'll return, is "Hello" concatenated
+            // to the value of the input parameter called "personsname".
+            PVString greetingvalueField = result.getStringField("greeting");
+            greetingvalueField.put("Hello " + inputPersonNameField.get());
 
-			return result;
-		}
-	}
+            return result;
+        }
+    }
 
-	/**
-	 * Main is the entry point of the HelloService server side executable. 
-	 * @param args None
-	 */
-	public static void main(String[] args) 
-	{
-		RPCServer server = new RPCServer();
-		// register our service as "helloService"
-		server.registerService("helloService", new HelloServiceImpl());
-		server.printInfo();
-		try {
-			server.run(0);
-		} catch (PVAException e) {
-			System.err.println(e.getMessage());
-			System.exit(1);
-		}
-	}
+    /**
+     * Main is the entry point of the HelloService server side executable. 
+     * @param args None
+     */
+    public static void main(String[] args) 
+    {
+        RPCServer server = new RPCServer();
+        // register our service as "helloService"
+        server.registerService("helloService", new HelloServiceImpl());
+        server.printInfo();
+        try {
+            server.run(0);
+        } catch (PVAException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+    }
 }

--- a/powerSupply/src/org/epics/exampleJava/powerSupply/PowerSupplyClient.java
+++ b/powerSupply/src/org/epics/exampleJava/powerSupply/PowerSupplyClient.java
@@ -21,21 +21,21 @@ public class PowerSupplyClient
 {
     public static void main( String[] args )
     {
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get("pva");
         try {
-        	PvaClientChannel pvaChannel = pva.channel("powerSupply");
-        	PvaClientPutGet putGet =pvaChannel.createPutGet(
-        	    "putField(power.value,voltage.value)getField()");
-        	putGet.connect();
-        	PvaClientPutData putData = putGet.getPutData();
-        	PvaClientGetData getData = putGet.getGetData();
-        	PVStructure pvStructure = putData.getPVStructure();
-        	PVDouble putPower = pvStructure.getSubField(PVDouble.class,"power.value");
-        	PVDouble putVoltage = pvStructure.getSubField(PVDouble.class,"voltage.value");
-        	putPower.put(5.0);
+            PvaClientChannel pvaChannel = pva.channel("powerSupply");
+            PvaClientPutGet putGet =pvaChannel.createPutGet(
+                    "putField(power.value,voltage.value)getField()");
+            putGet.connect();
+            PvaClientPutData putData = putGet.getPutData();
+            PvaClientGetData getData = putGet.getGetData();
+            PVStructure pvStructure = putData.getPVStructure();
+            PVDouble putPower = pvStructure.getSubField(PVDouble.class,"power.value");
+            PVDouble putVoltage = pvStructure.getSubField(PVDouble.class,"voltage.value");
+            putPower.put(5.0);
             putVoltage.put(5.0);
             putGet.putGet();
-            
+
             pvStructure = getData.getPVStructure();
             PVDouble getPower = pvStructure.getSubField(PVDouble.class,"power.value");
             PVDouble getVoltage = pvStructure.getSubField(PVDouble.class,"voltage.value");
@@ -46,7 +46,7 @@ public class PowerSupplyClient
 
             putPower.put(10.0);
             putGet.putGet();
-            
+
             pvStructure = getData.getPVStructure();
             getPower = pvStructure.getSubField(PVDouble.class,"power.value");
             getVoltage = pvStructure.getSubField(PVDouble.class,"voltage.value");

--- a/powerSupply/src/org/epics/exampleJava/powerSupply/PowerSupplyMain.java
+++ b/powerSupply/src/org/epics/exampleJava/powerSupply/PowerSupplyMain.java
@@ -11,7 +11,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
-import org.epics.pvaccess.PVAConstants;
 import org.epics.pvaccess.PVAException;
 import org.epics.pvaccess.client.ChannelProvider;
 import org.epics.pvaccess.server.impl.remote.ServerContextImpl;
@@ -35,7 +34,7 @@ public class PowerSupplyMain {
             String recordName = "powerSupply";
             PVRecord pvRecord = PowerSupplyRecord.create(recordName);
             master.addRecord(pvRecord);
-            ServerContextImpl context = ServerContextImpl.startPVAServer(PVAConstants.PVA_ALL_PROVIDERS,0,true,null);
+            ServerContextImpl context = ServerContextImpl.startPVAServer(channelProvider.getProviderName(),0,true,null);
             while(true) {
                 System.out.print("waiting for exit: ");
                 BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/powerSupply/src/org/epics/exampleJava/powerSupply/PowerSupplyMonitor.java
+++ b/powerSupply/src/org/epics/exampleJava/powerSupply/PowerSupplyMonitor.java
@@ -20,7 +20,7 @@ public class PowerSupplyMonitor {
 
     public static void main(String[] args)
     {   
-        PvaClient pva= PvaClient.get();
+        PvaClient pva= PvaClient.get("pva");
         try {
             PvaClientMonitor monitor = pva.channel("powerSupply").monitor("");
             while(true) {

--- a/powerSupply/src/org/epics/exampleJava/powerSupply/PowerSupplyRecord.java
+++ b/powerSupply/src/org/epics/exampleJava/powerSupply/PowerSupplyRecord.java
@@ -30,25 +30,25 @@ public class PowerSupplyRecord extends PVRecord
     private PVDouble pvVoltage = null;
     private PVAlarm pvAlarm = PVAlarmFactory.create();
     private Alarm alarm = new Alarm();
-    
+
     public static PowerSupplyRecord create(String recordName)
     {
         FieldCreate fieldCreate = FieldFactory.getFieldCreate();
         StandardField standardField = StandardFieldFactory.getStandardField();
         PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
         Structure topStructure = fieldCreate.createFieldBuilder().
-            add("alarm",standardField.alarm()).
-            add("timeStamp",standardField.timeStamp()).
-            addNestedStructure("power").
-               add("value",ScalarType.pvDouble).
-               endNested().
-            addNestedStructure("voltage").
-               add("value",ScalarType.pvDouble).
-               endNested().
-            addNestedStructure("current").
-               add("value",ScalarType.pvDouble).
-               endNested().
-            createStructure();
+                add("alarm",standardField.alarm()).
+                add("timeStamp",standardField.timeStamp()).
+                addNestedStructure("power").
+                add("value",ScalarType.pvDouble).
+                endNested().
+                addNestedStructure("voltage").
+                add("value",ScalarType.pvDouble).
+                endNested().
+                addNestedStructure("current").
+                add("value",ScalarType.pvDouble).
+                endNested().
+                createStructure();
         PVStructure pvStructure = pvDataCreate.createPVStructure(topStructure);
         PowerSupplyRecord pvRecord = new PowerSupplyRecord(recordName,pvStructure);
         if(!pvRecord.init()) return null;
@@ -58,7 +58,7 @@ public class PowerSupplyRecord extends PVRecord
     {
         super(recordName,pvStructure);
     }
-    
+
     private boolean init()
     {
         PVStructure pvStructure = getPVRecordStructure().getPVStructure();
@@ -66,28 +66,28 @@ public class PowerSupplyRecord extends PVRecord
         boolean result;
         pvField = pvStructure.getSubField(PVField.class,"alarm");
         if(pvField==null) {
-                System.out.println("no alarm");
-                return false;
+            System.out.println("no alarm");
+            return false;
         }
         result = pvAlarm.attach(pvField);
         if(!result) {
-                System.out.println("no alarm");
-                return false;
+            System.out.println("no alarm");
+            return false;
         }
         pvCurrent = pvStructure.getSubField(PVDouble.class,"current.value");
         if(pvCurrent==null) {
-                System.out.println("no current");
-                return false;
+            System.out.println("no current");
+            return false;
         }
         pvVoltage = pvStructure.getSubField(PVDouble.class,"voltage.value");
         if(pvVoltage==null) {
-                System.out.println("no current");
-                return false;
+            System.out.println("no current");
+            return false;
         }
         pvPower = pvStructure.getSubField(PVDouble.class,"power.value");
         if(pvPower==null) {
-                System.out.println("no power");
-                return false;
+            System.out.println("no power");
+            return false;
         }
         alarm.setMessage("bad voltage");
         alarm.setSeverity(AlarmSeverity.MAJOR);
@@ -95,7 +95,7 @@ public class PowerSupplyRecord extends PVRecord
         return true;
     }
 
-    
+
     public void process()
     {
         double voltage = pvVoltage.get();

--- a/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/ExampleRPCMain.java
+++ b/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/ExampleRPCMain.java
@@ -28,62 +28,62 @@ import org.epics.pvdatabase.pva.ChannelProviderLocalFactory;
  *
  */
 public class ExampleRPCMain {
-	static void usage() {
-		System.out.println("Usage:"
-				+ " -recordName name"
-				+ " -traceLevel traceLevel"
-				);
-	}
+    static void usage() {
+        System.out.println("Usage:"
+                + " -recordName name"
+                + " -traceLevel traceLevel"
+                );
+    }
 
-	private static String recordName = "mydevice";
-	private static int traceLevel = 0;
+    private static String recordName = "mydevice";
+    private static int traceLevel = 0;
 
-	public static void main(String[] args)
-	{
-		if(args.length==1 && args[0].equals("-help")) {
-			usage();
-			return;
-		}
-		int nextArg = 0;
-		while(nextArg<args.length) {
-			String arg = args[nextArg++];
-			if(arg.equals("-recordName")) {
-				recordName = args[nextArg++];
-				continue;
-			}
-			if(arg.equals("-traceLevel")) {
-				traceLevel = Integer.parseInt(args[nextArg++]);
-				continue;
-			} else {
-				System.out.println("Illegal options");
-				usage();
-				return;
-			}
-		}
-		try {
-			PVDatabase master = PVDatabaseFactory.getMaster();
-			ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
-			PVRecord pvRecord = ExampleRPCRecord.create(recordName);
-			pvRecord.setTraceLevel(traceLevel);
-			master.addRecord(pvRecord);
-			ServerContextImpl context = ServerContextImpl.startPVAServer(PVAConstants.PVA_ALL_PROVIDERS,0,true,null);
-			while(true) {
-				System.out.print("waiting for exit: ");
-				BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-				String value = null;
-				try {
-					value = br.readLine();
-				} catch (IOException ioe) {
-					System.out.println("IO error trying to read input!");
-				}
-				if(value.equals("exit")) break;
-			}
-			context.destroy();
-			master.destroy();
-			channelProvider.destroy();
-		} catch (PVAException e) {
-			System.err.println(e.getMessage());
-			System.exit(1);
-		}
-	}
+    public static void main(String[] args)
+    {
+        if(args.length==1 && args[0].equals("-help")) {
+            usage();
+            return;
+        }
+        int nextArg = 0;
+        while(nextArg<args.length) {
+            String arg = args[nextArg++];
+            if(arg.equals("-recordName")) {
+                recordName = args[nextArg++];
+                continue;
+            }
+            if(arg.equals("-traceLevel")) {
+                traceLevel = Integer.parseInt(args[nextArg++]);
+                continue;
+            } else {
+                System.out.println("Illegal options");
+                usage();
+                return;
+            }
+        }
+        try {
+            PVDatabase master = PVDatabaseFactory.getMaster();
+            ChannelProvider channelProvider = ChannelProviderLocalFactory.getChannelServer();
+            PVRecord pvRecord = ExampleRPCRecord.create(recordName);
+            pvRecord.setTraceLevel(traceLevel);
+            master.addRecord(pvRecord);
+            ServerContextImpl context = ServerContextImpl.startPVAServer(channelProvider.getProviderName(),0,true,null);
+            while(true) {
+                System.out.print("waiting for exit: ");
+                BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+                String value = null;
+                try {
+                    value = br.readLine();
+                } catch (IOException ioe) {
+                    System.out.println("IO error trying to read input!");
+                }
+                if(value.equals("exit")) break;
+            }
+            context.destroy();
+            master.destroy();
+            channelProvider.destroy();
+        } catch (PVAException e) {
+            System.err.println(e.getMessage());
+            System.exit(1);
+        }
+    }
 }

--- a/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/ExampleRPCRecord.java
+++ b/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/ExampleRPCRecord.java
@@ -57,49 +57,49 @@ public class ExampleRPCRecord extends PVRecord {
         private ExampleRPCRecord pvRecord;
 
         RPCServiceImpl(ExampleRPCRecord record) {
-                pvRecord = record;
+            pvRecord = record;
         }
 
-	    public PVStructure request(PVStructure args) throws RPCRequestException
+        public PVStructure request(PVStructure args) throws RPCRequestException
         {
             boolean haveControl = pvRecord.takeControl();
             if (!haveControl)
                 throw new RPCRequestException(StatusType.ERROR,
-                "Device busy");
+                        "Device busy");
 
             PVStructureArray valueField = args.getSubField(PVStructureArray.class,
-                  "value");
+                    "value");
             if (valueField == null)
                 throw new RPCRequestException(StatusType.ERROR,
-                    "No structure array value field");
+                        "No structure array value field");
 
             Structure valueFieldStructure = valueField.
-                getStructureArray().getStructure();
+                    getStructureArray().getStructure();
 
             Scalar xField = valueFieldStructure.getField(Scalar.class, "x");
             if (xField == null || xField.getScalarType() != ScalarType.pvDouble)
-                 throw new RPCRequestException(StatusType.ERROR,
-                    "value field's structure has no double field x");
+                throw new RPCRequestException(StatusType.ERROR,
+                        "value field's structure has no double field x");
 
             Scalar yField = valueFieldStructure.getField(Scalar.class, "y");
             if (yField == null || yField.getScalarType() != ScalarType.pvDouble)
-                 throw new RPCRequestException(StatusType.ERROR,
-                    "value field's structure has no double field y");
+                throw new RPCRequestException(StatusType.ERROR,
+                        "value field's structure has no double field y");
 
             int length = valueField.getLength();
             StructureArrayData sad = new StructureArrayData();
             valueField.get(0, length, sad);
-        
+
             for (int i = 0; i < length; i++)
             {
-        	    double x = sad.data[i].getSubField(PVDouble.class, "x").get();
-        	    double y = sad.data[i].getSubField(PVDouble.class, "y").get();
+                double x = sad.data[i].getSubField(PVDouble.class, "x").get();
+                double y = sad.data[i].getSubField(PVDouble.class, "y").get();
                 pvRecord.put(x,y);
                 try {
                     Thread.sleep(1000);
                 } catch (Exception e) {
                     throw new RPCRequestException(StatusType.ERROR,
-                       "Error in thread sleeping");
+                            "Error in thread sleeping");
                 }
             }
 
@@ -111,15 +111,15 @@ public class ExampleRPCRecord extends PVRecord {
     static class RPCServiceAsyncImpl implements RPCServiceAsync {
 
         private ExampleRPCRecord pvRecord;
-	    private final static Status statusOk = StatusFactory.
-            getStatusCreate().getStatusOK();
+        private final static Status statusOk = StatusFactory.
+                getStatusCreate().getStatusOK();
 
         RPCServiceAsyncImpl(ExampleRPCRecord record) {
-                pvRecord = record;
+            pvRecord = record;
 
         }
 
-	    public void request(PVStructure args, RPCResponseCallback callback)
+        public void request(PVStructure args, RPCResponseCallback callback)
         {
             boolean haveControl = pvRecord.takeControl();
             if (!haveControl)
@@ -129,7 +129,7 @@ public class ExampleRPCRecord extends PVRecord {
             }
 
             PVStructureArray valueField = args.getSubField(PVStructureArray.class,
-                  "value");
+                    "value");
             if (valueField == null)
             {
                 handleError("No structure array value field", callback, haveControl);
@@ -137,7 +137,7 @@ public class ExampleRPCRecord extends PVRecord {
             }
 
             Structure valueFieldStructure = valueField.
-                getStructureArray().getStructure();
+                    getStructureArray().getStructure();
 
             Scalar xField = valueFieldStructure.getField(Scalar.class, "x");
             if (xField == null || xField.getScalarType() != ScalarType.pvDouble)
@@ -156,17 +156,17 @@ public class ExampleRPCRecord extends PVRecord {
             int length = valueField.getLength();
             StructureArrayData sad = new StructureArrayData();
             valueField.get(0, length, sad);
-        
+
             for (int i = 0; i < length; i++)
             {
-        	    double x = sad.data[i].getSubField(PVDouble.class, "x").get();
-        	    double y = sad.data[i].getSubField(PVDouble.class, "y").get();
+                double x = sad.data[i].getSubField(PVDouble.class, "x").get();
+                double y = sad.data[i].getSubField(PVDouble.class, "y").get();
                 pvRecord.put(x,y);
                 try {
                     Thread.sleep(1000);
                 } catch (Exception e) {
-                   handleError("Error in thread sleeping", callback, haveControl);
-                   return;
+                    handleError("Error in thread sleeping", callback, haveControl);
+                    return;
                 }
             }
 
@@ -179,7 +179,7 @@ public class ExampleRPCRecord extends PVRecord {
             if (haveControl)
                 pvRecord.releaseControl();
             Status status = StatusFactory.getStatusCreate().
-                createStatus(StatusType.ERROR, message, null);
+                    createStatus(StatusType.ERROR, message, null);
             callback.requestDone(status, null);
         }
     }
@@ -188,14 +188,14 @@ public class ExampleRPCRecord extends PVRecord {
     {
         FieldBuilder fb = fieldCreate.createFieldBuilder();
         Structure structure = fb.
-            add("x",ScalarType.pvDouble).
-            add("y",ScalarType.pvDouble).
-            add("timeStamp",standardField.timeStamp()).
-            createStructure();
-       ExampleRPCRecord pvRecord = new ExampleRPCRecord(recordName, pvDataCreate.createPVStructure(structure));
-       PVDatabase master = PVDatabaseFactory.getMaster();
-       master.addRecord(pvRecord);
-       return pvRecord;
+                add("x",ScalarType.pvDouble).
+                add("y",ScalarType.pvDouble).
+                add("timeStamp",standardField.timeStamp()).
+                createStructure();
+        ExampleRPCRecord pvRecord = new ExampleRPCRecord(recordName, pvDataCreate.createPVStructure(structure));
+        PVDatabase master = PVDatabaseFactory.getMaster();
+        master.addRecord(pvRecord);
+        return pvRecord;
     }
 
     public ExampleRPCRecord(String recordName, PVStructure pvStructure) {

--- a/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/Move.java
+++ b/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/Move.java
@@ -20,76 +20,76 @@ import org.epics.pvdata.pv.*;
 
 public class Move
 {
-	static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
-	static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
-	static final double REQUEST_TIMEOUT = 3.0;
-	static final String DEVICE_NAME = "mydevice";
-	static final String APP_NAME = "move";
+    static final FieldCreate fieldCreate = FieldFactory.getFieldCreate();
+    static final PVDataCreate pvDataCreate = PVDataFactory.getPVDataCreate();
+    static final double REQUEST_TIMEOUT = 3.0;
+    static final String DEVICE_NAME = "mydevice";
+    static final String APP_NAME = "move";
 
-	static Structure deviceStructure = fieldCreate.createFieldBuilder().
-			add("x",ScalarType.pvDouble).
-			add("y",ScalarType.pvDouble).
-			createStructure();
+    static Structure deviceStructure = fieldCreate.createFieldBuilder().
+            add("x",ScalarType.pvDouble).
+            add("y",ScalarType.pvDouble).
+            createStructure();
 
-	static Structure requestStructure = fieldCreate.createFieldBuilder().
-			addArray("value",deviceStructure).
-			createStructure();
+    static Structure requestStructure = fieldCreate.createFieldBuilder().
+            addArray("value",deviceStructure).
+            createStructure();
 
-	static void usage() {
-		System.out.println("Usage:"
-				+  " [x_1 y_1] ... [x_n y_n]\n"
-				+ "Sequentially sets the values of the x and y fields of "
-				+ DEVICE_NAME + " to (x_i,y_i).\n"
-				+ "Returns on completion."
-				);
-	}
+    static void usage() {
+        System.out.println("Usage:"
+                +  " [x_1 y_1] ... [x_n y_n]\n"
+                + "Sequentially sets the values of the x and y fields of "
+                + DEVICE_NAME + " to (x_i,y_i).\n"
+                + "Returns on completion."
+                );
+    }
 
-	public static void main( String[] args )
-	{
-		int argc = args.length;
-		if(argc==1 && args[0].equals("-help")) {
-			usage();
-			return;
-		}
-		if ((argc % 2) != 0)
-		{
-			System.out.println(APP_NAME + " requires an even number of positions.");
-			usage();
-			System.exit(1);
-		}
-		if(argc==0) {
-			System.out.println(APP_NAME + " must have at least two positions.");
-			usage();
-			System.exit(1);
-		}
-		org.epics.pvaccess.ClientFactory.start();
-		try {
+    public static void main( String[] args )
+    {
+        int argc = args.length;
+        if(argc==1 && args[0].equals("-help")) {
+            usage();
+            return;
+        }
+        if ((argc % 2) != 0)
+        {
+            System.out.println(APP_NAME + " requires an even number of positions.");
+            usage();
+            System.exit(1);
+        }
+        if(argc==0) {
+            System.out.println(APP_NAME + " must have at least two positions.");
+            usage();
+            System.exit(1);
+        }
+        org.epics.pvaccess.ClientFactory.start();
+        try {
 
-			int npoints = argc/2;
-			PVStructure pvRequest = pvDataCreate.createPVStructure(requestStructure);
-			PVStructureArray pvStructureArray = pvRequest.getSubField(PVStructureArray.class, "value");
-			PVStructure[] values = new PVStructure[npoints];
-			int indarg = 0;
-			for(int i=0; i<npoints; ++i) {
-				values[i] = pvDataCreate.createPVStructure(deviceStructure);
-				PVDouble pvDouble = values[i].getSubField(PVDouble.class,"x");
-				pvDouble.put(Double.valueOf(args[indarg++]));
-				pvDouble = values[i].getSubField(PVDouble.class,"y");
-				pvDouble.put(Double.valueOf(args[indarg++]));
-		    }
-			pvStructureArray.put(0, npoints, values, 0);
-			pvStructureArray.setLength(npoints);
-			RPCClient rpcClient = RPCClientFactory.create(DEVICE_NAME);
-			PVStructure pvResult = rpcClient.request(pvRequest, 10.0);
-			System.out.println(pvResult.toString());
-		} catch (RPCRequestException e) {
-			System.out.println("exception " + e.getMessage());
-		}
-		finally
-		{
-			// Stop pvAccess client, so that this application exits cleanly.
-			org.epics.pvaccess.ClientFactory.stop();
-		}
-	}
+            int npoints = argc/2;
+            PVStructure pvRequest = pvDataCreate.createPVStructure(requestStructure);
+            PVStructureArray pvStructureArray = pvRequest.getSubField(PVStructureArray.class, "value");
+            PVStructure[] values = new PVStructure[npoints];
+            int indarg = 0;
+            for(int i=0; i<npoints; ++i) {
+                values[i] = pvDataCreate.createPVStructure(deviceStructure);
+                PVDouble pvDouble = values[i].getSubField(PVDouble.class,"x");
+                pvDouble.put(Double.valueOf(args[indarg++]));
+                pvDouble = values[i].getSubField(PVDouble.class,"y");
+                pvDouble.put(Double.valueOf(args[indarg++]));
+            }
+            pvStructureArray.put(0, npoints, values, 0);
+            pvStructureArray.setLength(npoints);
+            RPCClient rpcClient = RPCClientFactory.create(DEVICE_NAME);
+            PVStructure pvResult = rpcClient.request(pvRequest, 10.0);
+            System.out.println(pvResult.toString());
+        } catch (RPCRequestException e) {
+            System.out.println("exception " + e.getMessage());
+        }
+        finally
+        {
+            // Stop pvAccess client, so that this application exits cleanly.
+            org.epics.pvaccess.ClientFactory.stop();
+        }
+    }
 
 }


### PR DESCRIPTION
Client now only connect to required providers.
servers only create context for providers implemented by server.

In addition eclipse was used to make source indentation consistent.
The only change to eclipse default is to NOT use tabs.
Thus only spaces are used to indent
