### PR TITLE
 pvDatabaseRPC: Single update of record fields

### DIFF
--- a/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/Control.java
+++ b/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/Control.java
@@ -285,7 +285,7 @@ public class Control
             //System.out.println(pvResult);
             System.out.println("Done");
         } catch (RPCRequestException e) {
-            System.out.println("exception " + e.getMessage());
+            System.out.println("Exception: " + e.getMessage());
         }
         finally
         {

--- a/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/Device.java
+++ b/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/Device.java
@@ -104,10 +104,10 @@ public class Device implements RunnableReady
 
                             final double ds = Math.sqrt(dx*dx+dy*dy);
                             final double maxds = 0.01;
-                        // avoid very small final steps
-                        final double maxds_x = maxds + 1.0e-5;
+                            // avoid very small final steps
+                            final double maxds_x = maxds + 1.0e-5;
 
-                        if (ds > maxds_x)
+                            if (ds > maxds_x)
                             {
                                 double scale = maxds/ds;
                                 dx *= scale;

--- a/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/ExampleRPCRecord.java
+++ b/pvDatabaseRPC/src/org/epics/exampleJava/pvDatabaseRPC/ExampleRPCRecord.java
@@ -167,8 +167,6 @@ public class ExampleRPCRecord extends PVRecord implements Device.Callback
         TimeStamp timeStamp = TimeStampFactory.create();
         timeStamp.getCurrentTime();
 
-        boolean updateSPTimeStamp = firstTime;
-
         Point newSP = new Point(pvx.get(), pvy.get()); 
         try
         {


### PR DESCRIPTION
Update fields of record as single update rather than in several goes. Prevents overruns and avoids issues with missed updates.

Minor change to client application output.
